### PR TITLE
feat: bump golangcilint to v1.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ RUN apk add --no-cache --upgrade \
     grep \
     g++ \
     git \
-    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1 \
+    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.1 \
     && go install github.com/matryer/moq@v0.3.0


### PR DESCRIPTION
Bump golangci-lint to v1.5.1.